### PR TITLE
Do not include nwb-project-analytics data in code count

### DIFF
--- a/src/nwb_project_analytics/codestats.py
+++ b/src/nwb_project_analytics/codestats.py
@@ -491,7 +491,12 @@ class GitCodeStats:
         Run CLOC on the given srcdir, save the results to outdir, and return the parsed
         results.
         """
-        command = "%s --yaml --report-file=%s %s" % (cloc_path, out_file, src_dir)
+        # Check if this is the nwb-project-analytics repository and exclude data directory
+        repo_name = os.path.basename(src_dir)
+        if repo_name == "nwb-project-analytics":
+            command = "%s --yaml --report-file=%s --exclude-dir=data %s" % (cloc_path, out_file, src_dir)
+        else:
+            command = "%s --yaml --report-file=%s %s" % (cloc_path, out_file, src_dir)
         try:
             os.system(command)
             yaml_safe_loader = yaml.YAML(typ='safe', pure=True)


### PR DESCRIPTION
A quick fix for this repo. Fix #48

```
cd nwb-project-analytics
cloc --yaml --report-file=temp.yaml .
# returns code: 229073
```

```
cloc --yaml --report-file=temp.yaml --exclude-dir=data .
# returns code: 5677
```

