### PR TITLE
Fix exclude data on nwb project analytics repo

### DIFF
--- a/src/nwb_project_analytics/codestats.py
+++ b/src/nwb_project_analytics/codestats.py
@@ -493,7 +493,7 @@ class GitCodeStats:
         """
         # Check if this is the nwb-project-analytics repository and exclude data directory
         repo_name = os.path.basename(src_dir)
-        if repo_name == "nwb-project-analytics":
+        if repo_name == "NWB_Project_Analytics":
             command = "%s --yaml --report-file=%s --exclude-dir=data %s" % (cloc_path, out_file, src_dir)
         else:
             command = "%s --yaml --report-file=%s %s" % (cloc_path, out_file, src_dir)


### PR DESCRIPTION
I thought #49 fixed the issue where data yaml in this repo were being counted, but apparently the source dir name is different from the repo name so it did not work. This fixes that issue and updates the cached data.

Cache update on the way